### PR TITLE
🛡️ Sentinel: [MEDIUM] Add maxContentLength validation to API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-19 - DoS Protection on Analyze Endpoint
+**Vulnerability:** The `/analyze` endpoint accepted unconstrained `content` string lengths in its request payload, leading to potential Denial of Service (DoS) attacks as memory consumption and pipeline processing time scaled linearly with payload size.
+**Learning:** External-facing APIs must restrict the maximum size of input payloads explicitly before any complex parsing, extraction, or downstream pipeline steps process the data.
+**Prevention:** Implement `maxContentLength` in application configurations and explicitly check the `content.length` at the API layer, returning an immediate `413 Payload Too Large` error for oversized inputs to reject them cheaply.

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 
 import { generateWcpDecision } from "./entrypoints/wcp-entrypoint.js";
 import { formatApiError, ValidationError } from "./utils/errors.js";
+import { getAppConfig } from "./config/app-config.js";
 
 async function handleAnalyzeRequest(c: any) {
   try {
@@ -17,6 +18,12 @@ async function handleAnalyzeRequest(c: any) {
     if (typeof content !== "string") {
       const error = new ValidationError("Content must be a string");
       return c.json(formatApiError(error), 400);
+    }
+
+    const config = getAppConfig();
+    if (content.length > config.api.maxContentLength) {
+      const error = new ValidationError("Content exceeds maximum allowed length");
+      return c.json(formatApiError(error), 413);
     }
 
     const result = await generateWcpDecision({

--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -40,6 +40,8 @@ export interface ApiConfig {
   cors: boolean;
   /** Request timeout (ms) */
   timeout: number;
+  /** Max content length */
+  maxContentLength: number;
 }
 
 /**
@@ -88,6 +90,7 @@ export function getAppConfig(): AppConfig {
       host: process.env.HOST || 'localhost',
       cors: process.env.ENABLE_CORS !== 'false',
       timeout: parseInt(process.env.API_TIMEOUT || '30000', 10),
+      maxContentLength: parseInt(process.env.MAX_CONTENT_LENGTH || '10000', 10),
     },
     observability: {
       enabled: process.env.OBSERVABILITY_ENABLED === 'true' || environment === 'production',
@@ -113,6 +116,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
     host: 'localhost',
     cors: true,
     timeout: 30000,
+    maxContentLength: 10000,
   },
   observability: {
     enabled: false,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/analyze` endpoint lacked input payload length validation, potentially allowing malicious actors to send excessively large payloads leading to Denial of Service (DoS) due to high memory consumption and processing times.
🎯 Impact: Attackers could degrade service performance or cause the application to crash by exhausting available resources.
🔧 Fix: Implemented `maxContentLength` in application configuration (defaulting to 10,000 chars, overridable via `MAX_CONTENT_LENGTH` environment variable). Added validation logic in `handleAnalyzeRequest` to immediately return a `413 Payload Too Large` error for payloads exceeding this limit, rejecting them cheaply before processing. Documented learnings in `.jules/sentinel.md`.
✅ Verification: Tested locally via API calls to ensure valid requests are accepted and oversized requests are correctly blocked with a 413 error. Ran unit/integration tests to ensure no regressions.

---
*PR created automatically by Jules for task [1508551795843916724](https://jules.google.com/task/1508551795843916724) started by @FishRaposo*