### PR TITLE
🎨 Palette: Accessibility improvements for icon-only inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-20 - Missing ARIA Labels and Focus States on Icon-Only Inputs
+**Learning:** Found an accessibility pattern where icon-only buttons (like password visibility toggles) lacked `aria-label` attributes and keyboard focus styles, and inputs lacked proper explicit label associations.
+**Action:** Next time, search for interactive elements with only icon children and ensure they have `aria-label`s, proper focus indicators using `.focus-visible`, and explicit labels mapping for text inputs.

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -134,8 +134,9 @@ export default function App() {
 
           {/* Input */}
           <div className="space-y-3">
-            <p className="text-xs text-slate-500 uppercase tracking-wider font-medium">Or enter custom payroll text</p>
+            <label htmlFor="payroll-input" className="block text-xs text-slate-500 uppercase tracking-wider font-medium">Or enter custom payroll text</label>
             <textarea
+              id="payroll-input"
               className="w-full h-28 bg-slate-900 border border-slate-700 rounded-xl px-4 py-3 text-sm text-slate-200 placeholder-slate-600 resize-none focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent transition"
               placeholder="e.g. Role: Electrician, Hours: 45, Wage: 35.00, Fringe: 20.00"
               value={content}
@@ -147,6 +148,7 @@ export default function App() {
               <button
                 onClick={analyze}
                 disabled={loading || !content.trim()}
+                aria-busy={loading}
                 className="flex items-center gap-2 bg-violet-600 hover:bg-violet-500 disabled:bg-slate-700 disabled:text-slate-500 text-white text-sm font-medium px-5 py-2.5 rounded-lg transition-colors disabled:cursor-not-allowed"
               >
                 {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Shield className="w-4 h-4" />}

--- a/src/frontend/components/KeyInput.tsx
+++ b/src/frontend/components/KeyInput.tsx
@@ -16,6 +16,7 @@ export function KeyInput({ apiKey, onChange, isMockMode }: KeyInputProps) {
         <Key className="w-4 h-4 text-slate-500 absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
         <input
           type={visible ? 'text' : 'password'}
+          aria-label="OpenAI API key"
           placeholder="OpenAI API key (optional — never stored, used only for this request)"
           value={apiKey}
           onChange={e => onChange(e.target.value)}
@@ -25,8 +26,9 @@ export function KeyInput({ apiKey, onChange, isMockMode }: KeyInputProps) {
         />
         <button
           type="button"
+          aria-label={visible ? 'Hide API key' : 'Show API key'}
           onClick={() => setVisible(v => !v)}
-          className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300 transition-colors"
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 rounded p-0.5 transition-colors"
         >
           {visible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
         </button>


### PR DESCRIPTION
💡 What: Added ARIA labels and focus states to the API key visibility toggle. Connected the custom payroll text `<textarea>` to a proper semantic `<label>` using the `htmlFor`/`id` mapping. Added an `aria-busy` attribute to the main "Analyze" button during loading states.

🎯 Why: To improve the user experience for those using screen readers and keyboard navigation. The toggle icon-button previously lacked an accessible name or clear focus outline, making it opaque to assistive technologies. The unassociated text area made it difficult for screen readers to properly announce the input context. The main submit button now conveys its loading status to screen readers.

📸 Before/After: Before, there was no focus-ring on the eye-icon, no spoken label for the API input button, and a missing explicit label on the large text area. After, focus states work clearly and screen readers announce the element correctly.

♿ Accessibility: Ensures that keyboard-only users can clearly see when the visibility toggle is focused. Screen reader users can understand the context of the main input and the purpose of the icon-only toggle buttons.

---
*PR created automatically by Jules for task [601119893705045142](https://jules.google.com/task/601119893705045142) started by @FishRaposo*